### PR TITLE
fix typo StreamExection to StreamExecution

### DIFF
--- a/Structured Streaming 源码解析系列/2.1 Structured Streaming 之 Source 解析.md
+++ b/Structured Streaming 源码解析系列/2.1 Structured Streaming 之 Source 解析.md
@@ -45,12 +45,12 @@ trait Source  {
 
 ![Spark 1.0](1.imgs/110.png)
 
-1. 在每个 StreamExection 的批次最开始，StreamExection 会向 Source 询问当前 Source 的最新进度，即最新的 offset
+1. 在每个 StreamExecution 的批次最开始，StreamExecution 会向 Source 询问当前 Source 的最新进度，即最新的 offset
      - 这里是由 StreamExecution 调用 Source 的 `def getOffset: Option[Offset]`，即方法 (2)
      - Kafka (KafkaSource) 的具体 `getOffset()` 实现 ，会通过在 driver 端的一个长时运行的 consumer 从 kafka brokers 处获取到各个 topic 最新的 offsets（注意这里不存在 driver 或 consumer 直接连 zookeeper），比如 `topicA_partition1:300, topicB_partition1:50, topicB_partition2:60`，并把 offsets 返回
      - HDFS-compatible file system (FileStreamSource) 的具体 `getOffset()` 实现，是先扫描一下最新的一组文件，给一个递增的编号并持久化下来，比如 `2 -> {c.txt, d.txt}`，然后把编号 `2` 作为最新的 offset 返回
-2. 这个 Offset 给到 StreamExection 后会被 StreamExection 持久化到自己的 WAL 里
-3. 由 Source 根据 StreamExection 所要求的 start offset、end offset，提供在 `(start, end]` 区间范围内的数据
+2. 这个 Offset 给到 StreamExecution 后会被 StreamExecution 持久化到自己的 WAL 里
+3. 由 Source 根据 StreamExecution 所要求的 start offset、end offset，提供在 `(start, end]` 区间范围内的数据
      - 这里是由 StreamExecution 调用 Source 的 `def getBatch(start: Option[Offset], end: Offset): DataFrame`，即方法 (3)
      - 这里的 start offset 和 end offset，通常就是 Source 在上一个执行批次里提供的最新 offset，和 Source 在这个批次里提供的最新 offset；但需要注意区间范围是 ***左开右闭*** ！
      - 数据的返回形式的是一个 DataFrame（这个 DataFrame 目前只包含数据的描述信息，并没有发生实际的取数据操作）

--- a/Structured Streaming 源码解析系列/2.2 Structured Streaming 之 Sink 解析.md
+++ b/Structured Streaming 源码解析系列/2.2 Structured Streaming 之 Sink 解析.md
@@ -43,12 +43,12 @@ trait Sink {
 
 ![Spark 1.0](1.imgs/110.png)
 
-1. 在每个 StreamExection 的批次最开始，StreamExection 会向 Source 询问当前 Source 的最新进度，即最新的 offset
-2. 这个 Offset 给到 StreamExection 后会被 StreamExection 持久化到自己的 WAL 里
-3. 由 Source 根据 StreamExection 所要求的 start offset、end offset，提供在 `(start, end]` 区间范围内的数据
+1. 在每个 StreamExecution 的批次最开始，StreamExecution 会向 Source 询问当前 Source 的最新进度，即最新的 offset
+2. 这个 Offset 给到 StreamExecution 后会被 StreamExecution 持久化到自己的 WAL 里
+3. 由 Source 根据 StreamExecution 所要求的 start offset、end offset，提供在 `(start, end]` 区间范围内的数据
 4. StreamExecution 触发计算逻辑 logicalPlan 的优化与编译
 5. 把计算结果写出给 Sink
-     - 具体是由 StreamExection 调用 `Sink.addBatch(batchId: Long, data: DataFrame)`
+     - 具体是由 StreamExecution 调用 `Sink.addBatch(batchId: Long, data: DataFrame)`
      - 注意这时才会由 Sink 触发发生实际的取数据操作，以及计算过程
      - 通常 Sink 直接可以直接把 `data: DataFrame` 的数据写出，并在完成后记录下 `batchId: Long`
      - 在故障恢复时，分两种情况讨论：


### PR DESCRIPTION
In the 2.1 MD, `StreamExection` should be a typo. Fix it to `StreamExecution`.