### PR TITLE
modifiy Spark Streaming 源码解析系列/Receiver 分发详解.md

### DIFF
--- a/Spark Streaming 源码解析系列/3.1 Receiver 分发详解.md
+++ b/Spark Streaming 源码解析系列/3.1 Receiver 分发详解.md
@@ -101,7 +101,7 @@ Spark 1.4.0 的 `launchReceivers()` 的过程如下：
   - 然后就调用 `ReceiverSchedulingPolicy.scheduleReceivers(receivers, executors)` 来计算每个 `Receiver` 的目的地 executor 列表
 
 - 在 Streaming 程序运行过程中，如果需要重启某个 `Receiver`：
-  - 将首先看一看之前计算过的目的地 executor 还没有还 alive 的
+  - 将首先看一看之前计算过的目的地 executor 有没有还 alive 的
   - 如果没有，就需要 `ReceiverSchedulingPolicy.rescheduleReceiver(receiver, ...)` 来重新计算这个 `Receiver` 的目的地 executor 列表
 
 [默认的 `ReceiverSchedulingPolicy`](https://github.com/apache/spark/blob/master/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverSchedulingPolicy.scala) 是实现为 `round-robin` 式的了。我们举例说明下这两个方法：


### PR DESCRIPTION
修改：“Spark Streaming 源码解析系列/Receiver 分发详解.md" 中“将首先看一看之前计算过的目的地 executor 还没有还 alive 的” 改为 “将首先看一看之前计算过的目的地 executor 有没有还 alive 的”